### PR TITLE
Persistent graph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ install_requires = [
     "gitpython>=2.0,<3.0",
     "jinja2>=2.7,<3.0",
     "schematics>=2.0.1,<2.1.0",
-    "formic2",
-    "python-dateutil>=2.0,<3.0",
+    "formic2"
 ]
 
 setup_requires = ['pytest-runner']

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -44,6 +44,7 @@ class Stacker(BaseCommand):
         options.context = Context(
             environment=options.environment,
             config=self.config,
+            region=options.region,
             # Allow subcommands to provide any specific kwargs to the Context
             # that it wants.
             **options.get_context_kwargs(options)

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -402,6 +402,8 @@ class Config(Model):
 
     stacker_bucket_region = StringType(serialize_when_none=False)
 
+    persistent_graph_key = StringType(serialize_when_none=False)
+
     stacker_cache_dir = StringType(serialize_when_none=False)
 
     sys_path = StringType(serialize_when_none=False)

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -3,11 +3,20 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import object
 import collections
+import json
 import logging
 
 from stacker.config import Config
+from .exceptions import (PersistentGraphCannotLock,
+                         PersistentGraphCannotUnlock,
+                         PersistentGraphLocked,
+                         PersistentGraphLockCodeMissmatch,
+                         PersistentGraphUnlocked)
+from .plan import Graph
+from .session_cache import get_session
 from .stack import Stack
 from .target import Target
+from .util import ensure_s3_bucket
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +51,7 @@ class Context(object):
             usually all stacks defined in the config will be operated on.
         config (:class:`stacker.config.Config`): The stacker configuration
             being operated on.
+        region (str): Name of an AWS region if provided as a CLI argument.
         force_stacks (list): A list of stacks to force work on. Used to work
             on locked stacks.
 
@@ -50,12 +60,43 @@ class Context(object):
     def __init__(self, environment=None,
                  stack_names=None,
                  config=None,
+                 region=None,
                  force_stacks=None):
-        self.environment = environment
-        self.stack_names = stack_names or []
+        self._bucket_name = None
+        self._persistent_graph = None
+        self._persistent_graph_lock_code = None
+        self._persistent_graph_lock_tag = 'stacker_lock_code'
+        self._s3_bucket_verified = None
+        self._upload_to_s3 = None
+        self.bucket_region = config.stacker_bucket_region or region
         self.config = config or Config()
+        self.environment = environment
         self.force_stacks = force_stacks or []
         self.hook_data = {}
+        self.s3_conn = get_session(self.bucket_region).client('s3')
+        self.stack_names = stack_names or []
+
+    @property
+    def _base_fqn(self):
+        return self.namespace.replace(".", "-").lower()
+
+    @property
+    def _persistent_graph_tags(self):
+        """Cached dict of tags on the persistent graph object.
+
+        Returns:
+            (Dict[str, str])
+
+        """
+        try:
+            return {t['Key']: t['Value'] for t in
+                    self.s3_conn.get_object_tagging(
+                    **self.persistent_graph_location
+                    ).get('TagSet', {})}
+        except self.s3_conn.exceptions.NoSuchKey:
+            logger.debug('Persistant graph object does not exist in S3; '
+                         'could not get tags')
+            return {}
 
     @property
     def namespace(self):
@@ -77,32 +118,130 @@ class Context(object):
 
     @property
     def bucket_name(self):
-        if not self.upload_templates_to_s3:
+        """Stacker bucket name."""
+        if not self.upload_to_s3:
             return None
-
-        return self.config.stacker_bucket \
-            or "stacker-%s" % (self.get_fqn(),)
+        if not self._bucket_name:
+            self._bucket_name = self.config.stacker_bucket \
+                or "stacker-%s" % (self.get_fqn())
+        return self._bucket_name
 
     @property
-    def upload_templates_to_s3(self):
-        # Don't upload stack templates to S3 if `stacker_bucket` is explicitly
-        # set to an empty string.
-        if self.config.stacker_bucket == '':
-            logger.debug("Not uploading templates to s3 because "
-                         "`stacker_bucket` is explicity set to an "
-                         "empty string")
-            return False
+    def mappings(self):
+        return self.config.mappings or {}
 
-        # If no namespace is specificied, and there's no explicit stacker
-        # bucket specified, don't upload to s3. This makes sense because we
-        # can't realistically auto generate a stacker bucket name in this case.
-        if not self.namespace and not self.config.stacker_bucket:
-            logger.debug("Not uploading templates to s3 because "
-                         "there is no namespace set, and no "
-                         "stacker_bucket set")
-            return False
+    @property
+    def persistent_graph(self):
+        """Persistent graph object if one is to be used.
 
+        Will create an "empty" object in S3 if one is not found.
+
+        Returns:
+            (:class:`stacker.plan.Graph`)
+
+        """
+        if not self.persistent_graph_location:
+            return None
+
+        content = '{}'
+
+        if not self._persistent_graph:
+            if self.s3_bucket_verified:
+                try:
+                    logger.debug('Getting persistent graph from s3:\n%s',
+                                 json.dumps(self.persistent_graph_location,
+                                            indent=4))
+                    content = self.s3_conn.get_object(
+                        ResponseContentType='application/json',
+                        **self.persistent_graph_location
+                    )['Body'].read().decode('utf-8')
+                except self.s3_conn.exceptions.NoSuchKey:
+                    logger.info('Persistant graph object does not exist '
+                                'in S3; creating one now.')
+                    self.s3_conn.put_object(
+                        Body=content,
+                        ServerSideEncryption='AES256',
+                        ACL='bucket-owner-full-control',
+                        ContentType='application/json',
+                        **self.persistent_graph_location
+                    )
+            self.persistent_graph = json.loads(content)
+
+        return self._persistent_graph
+
+    @persistent_graph.setter
+    def persistent_graph(self, graph_dict):
+        """Load a persistent graph dict as a :class:`stacker.plan.Graph`."""
+        self._persistent_graph = Graph.from_dict(graph_dict, self)
+
+    @property
+    def persistent_graph_location(self):
+        """Location of the persistent graph in s3.
+
+        Returns:
+            (Dict[str, str]) Bucket and Key for the object in S3.
+
+        """
+        if not self.upload_to_s3 or not self.config.persistent_graph_key:
+            return {}
+
+        return {
+            'Bucket': self.bucket_name,
+            'Key': 'persistent_graphs/{namespace}/{key}'.format(
+                namespace=self.config.namespace,
+                key=(self.config.persistent_graph_key + '.json' if not
+                     self.config.persistent_graph_key.endswith('.json')
+                     else self.config.persistent_graph_key)
+            )
+        }
+
+    @property
+    def persistent_graph_lock_code(self):
+        """Code used to lock the persistent graph S3 object.
+
+        Returns:
+            (Optional[str])
+
+        """
+        if not self._persistent_graph_lock_code:
+            self._persistent_graph_lock_code = self._persistent_graph_tags.get(
+                self._persistent_graph_lock_tag
+            )
+        return self._persistent_graph_lock_code
+
+    @property
+    def persistent_graph_locked(self):
+        """Check if persistent graph is locked.
+
+        Returns:
+            (bool)
+
+        """
+        if not self.persistent_graph:
+            return False
+        if not self.persistent_graph_lock_code:
+            return False
         return True
+
+    @property
+    def s3_bucket_verified(self):
+        """Check Stacker bucket exists and you have access.
+
+        If the Stacker bucket does not exist, will try to create one.
+
+        Returns:
+            (bool)
+
+        """
+        if not self._s3_bucket_verified and self.bucket_name:
+            ensure_s3_bucket(self.s3_conn,
+                             self.bucket_name,
+                             self.bucket_region,
+                             persist_graph=(True if
+                                            self.persistent_graph_location
+                                            else False))
+            self._s3_bucket_verified = True
+        return self._s3_bucket_verified
 
     @property
     def tags(self):
@@ -114,12 +253,31 @@ class Context(object):
         return {}
 
     @property
-    def _base_fqn(self):
-        return self.namespace.replace(".", "-").lower()
+    def upload_to_s3(self):
+        """Check if S3 should be used for caching/persistent graph.
 
-    @property
-    def mappings(self):
-        return self.config.mappings or {}
+        Returns:
+            (bool)
+
+        """
+        if not self._upload_to_s3:
+            # Don't upload stack templates to S3 if `stacker_bucket` is
+            # explicitly set to an empty string.
+            if self.config.stacker_bucket == '':
+                logger.debug("Not uploading to s3 because `stacker_bucket` "
+                             "is explicitly set to an empty string")
+                return False
+
+            # If no namespace is specificied, and there's no explicit
+            # stacker bucket specified, don't upload to s3. This makes
+            # sense because we can't realistically auto generate a stacker
+            # bucket name in this case.
+            if not self.namespace and not self.config.stacker_bucket:
+                logger.debug("Not uploading to s3 because there is no "
+                             "namespace set, and no stacker_bucket set")
+                return False
+
+        return True
 
     def _get_stack_definitions(self):
         return self.config.stacks
@@ -183,6 +341,80 @@ class Context(object):
         """
         return get_fqn(self._base_fqn, self.namespace_delimiter, name)
 
+    def lock_persistent_graph(self, lock_code):
+        """Locks the persistent graph in s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`stacker.exceptions.PersistentGraphLocked`
+            :class:`stacker.exceptions.PersistentGraphCannotLock`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        if self.persistent_graph_locked:
+            raise PersistentGraphLocked
+
+        try:
+            self.s3_conn.put_object_tagging(
+                Tagging={'TagSet': [
+                    {'Key': self._persistent_graph_lock_tag,
+                     'Value': lock_code}
+                ]},
+                **self.persistent_graph_location
+            )
+            logger.info('Locked persistent graph "%s" with lock ID "%s".',
+                        '/'.join([self.persistent_graph_location['Bucket'],
+                                  self.persistent_graph_location['Key']]),
+                        lock_code)
+        except self.s3_conn.exceptions.NoSuchKey:
+            raise PersistentGraphCannotLock('s3 object does not exist')
+
+    def put_persistent_graph(self, lock_code):
+        """Upload persistent graph to s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`stacker.exceptions.PersistentGraphUnlocked`
+            :class:`stacker.exceptions.PersistentGraphLockCodeMissmatch`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        if not self.persistent_graph_locked:
+            raise PersistentGraphUnlocked(
+                reason='It must be locked by the current session to be '
+                       'updated.'
+            )
+
+        if self.persistent_graph_lock_code != lock_code:
+            raise PersistentGraphLockCodeMissmatch(
+                lock_code, self.persistent_graph_lock_code
+            )
+
+        if not self.persistent_graph.to_dict():
+            self.s3_conn.delete_object(**self.persistent_graph_location)
+            logger.debug('Removed empty persistent graph object from S3')
+            return
+
+        self.s3_conn.put_object(
+            Body=self.persistent_graph.dumps(4),
+            ServerSideEncryption='AES256',
+            ACL='bucket-owner-full-control',
+            ContentType='application/json',
+            Tagging='{}={}'.format(self._persistent_graph_lock_tag,
+                                   lock_code),
+            **self.persistent_graph_location
+        )
+        logger.debug('Persistent graph updated:\n%s',
+                     self.persistent_graph.dumps(indent=4))
+
     def set_hook_data(self, key, data):
         """Set hook data for the given key.
 
@@ -202,3 +434,44 @@ class Context(object):
                            "must have a unique data_key.", key)
 
         self.hook_data[key] = data
+
+    def unlock_persistent_graph(self, lock_code):
+        """Unlocks the persistent graph in s3.
+
+        Args:
+            lock_code (str): The code that will be used to lock the S3 object.
+
+        Raises:
+            :class:`stacker.exceptions.PersistentGraphCannotUnlock`
+
+        """
+        if not self.persistent_graph:
+            return
+
+        logger.debug('Unlocking persistent graph "%s".',
+                     self.persistent_graph_location)
+
+        if not self.persistent_graph_locked:
+            raise PersistentGraphCannotUnlock(PersistentGraphUnlocked(
+                reason='It must be locked by the current session to be '
+                       'unlocked.'
+            ))
+
+        if self.persistent_graph_lock_code == lock_code:
+            try:
+                self.s3_conn.delete_object_tagging(
+                    **self.persistent_graph_location
+                )
+            except self.s3_conn.exceptions.NoSuchKey:
+                pass
+            self._persistent_graph_lock_code = None
+            logger.info('Unlocked persistent graph "%s".',
+                        '/'.join([self.persistent_graph_location['Bucket'],
+                                  self.persistent_graph_location['Key']]))
+            return True
+        raise PersistentGraphCannotUnlock(
+            PersistentGraphLockCodeMissmatch(
+                lock_code,
+                self.persistent_graph_lock_code
+            )
+        )

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -273,3 +273,66 @@ class GraphError(Exception):
             "as a dependency of '%s': %s"
         ) % (dependency, stack, str(exception))
         super(GraphError, self).__init__(message)
+
+
+class PersistentGraphCannotLock(Exception):
+    """Raised when the persistent graph in S3 cannot be locked."""
+
+    def __init__(self, reason):
+        """Instantiate class."""
+        message = "Could not lock persistent graph; %s" % reason
+        super(PersistentGraphCannotLock, self).__init__(message)
+
+
+class PersistentGraphCannotUnlock(Exception):
+    """Raised when the persistent graph in S3 cannot be unlocked."""
+
+    def __init__(self, reason):
+        """Instantiate class."""
+        message = "Could not unlock persistent graph; %s" % reason
+        super(PersistentGraphCannotUnlock, self).__init__(message)
+
+
+class PersistentGraphLocked(Exception):
+    """
+    Raised when the persistent graph in S3 is lock and an action requiring
+    it to be unlocked is attempted.
+    """
+
+    def __init__(self, message=None, reason=None):
+        """Instantiate class."""
+        if not message:
+            message = ("Persistant graph is locked. {}".format(
+                reason or ("This action requires the graph to be "
+                           "unlocked to be executed.")
+            ))
+        super(PersistentGraphLocked, self).__init__(message)
+
+
+class PersistentGraphLockCodeMissmatch(Exception):
+    """
+    Raised when the provided persistent graph lock code does not match
+    the s3 object lock code.
+    """
+
+    def __init__(self, provided_code, s3_code):
+        """Instantiate class."""
+        message = ("The provided lock code '%s' does not match the S3 "
+                   "object lock code '%s'" % (provided_code, s3_code))
+        super(PersistentGraphLockCodeMissmatch, self).__init__(message)
+
+
+class PersistentGraphUnlocked(Exception):
+    """
+    Raised when the persistent graph in S3 is unlock and an action
+    requiring it to be locked is attempted.
+    """
+
+    def __init__(self, message=None, reason=None):
+        """Instantiate class."""
+        if not message:
+            message = ("Persistant graph is unlocked. {}".format(
+                reason or ("This action requires the graph to be "
+                           "locked to be executed.")
+            ))
+        super(PersistentGraphLocked, self).__init__(message)

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -3,19 +3,23 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import object
 import os
+import json
 import logging
 import time
 import uuid
 import threading
 
-from .util import stack_template_key_name
+from .util import stack_template_key_name, merge_map
 from .exceptions import (
+    CancelExecution,
     GraphError,
     PlanFailed,
+    PersistentGraphLocked
 )
 from .ui import ui
 from .dag import DAG, DAGValidationError, walk
 from .status import (
+    SkippedStatus,
     FailedStatus,
     PENDING,
     SUBMITTED,
@@ -33,6 +37,21 @@ COLOR_CODES = {
 }
 
 
+def json_serial(obj):
+    """Serialize json.
+
+    Args:
+        obj (Any): A python object.
+
+    Example:
+        json.dumps(data, default=json_serial)
+
+    """
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError
+
+
 def log_step(step):
     msg = "%s: %s" % (step, step.status.name)
     if step.status.reason:
@@ -41,18 +60,39 @@ def log_step(step):
     ui.info(msg, extra={"color": color_code})
 
 
+def merge_graphs(graph1, graph2):
+    """Combine two Graphs into one, retaining steps.
+
+    Args:
+        graph1 (:class:`Graph`): Graph that ``graph2`` will
+            be merged into.
+        graph2 (:class:`Graph`): Graph that will be merged
+            into ``graph1``.
+
+    Returns:
+        (:class:`Graph`) A combined graph.
+
+    """
+    merged_graph_dict = merge_map(graph1.to_dict().copy(),
+                                  graph2.to_dict())
+    steps = [graph1.steps.get(name, graph2.steps.get(name))
+             for name in merged_graph_dict.keys()]
+    return Graph.from_steps(steps)
+
+
 class Step(object):
     """State machine for executing generic actions related to stacks.
+
     Args:
-        stack (:class:`stacker.stack.Stack`): the stack associated
-            with this step
-        fn (func): the function to run to execute the step. This function will
-            be ran multiple times until the step is "done".
-        watch_func (func): an optional function that will be called to "tail"
-            the step action.
+        stack (:class:`Stack`): the stack associated with this step.
+        fn (Callable): the function to run to execute the step. This
+            function will be ran multiple times until the step is "done".
+        watch_func (Callable): an optional function that will be called
+            to "tail" the step action.
+
     """
 
-    def __init__(self, stack, fn, watch_func=None):
+    def __init__(self, stack, fn=None, watch_func=None):
         self.stack = stack
         self.status = PENDING
         self.last_updated = time.time()
@@ -91,9 +131,11 @@ class Step(object):
     def _run_once(self):
         try:
             status = self.fn(self.stack, status=self.status)
-        except Exception as e:
-            logger.exception(e)
-            status = FailedStatus(reason=str(e))
+        except CancelExecution:
+            status = SkippedStatus('canceled execution')
+        except Exception as err:
+            logger.exception(err)
+            status = FailedStatus(reason=str(err))
         self.set_status(status)
         return status
 
@@ -166,58 +208,60 @@ class Step(object):
         """A shortcut for set_status(SUBMITTED)"""
         self.set_status(SUBMITTED)
 
+    @classmethod
+    def from_stack_name(cls, stack_name, context, requires=None, fn=None,
+                        watch_func=None):
+        """Create a step using only a stack name.
 
-def build_plan(description, graph,
-               targets=None, reverse=False):
-    """Builds a plan from a list of steps.
-    Args:
-        description (str): an arbitrary string to
-            describe the plan.
-        graph (:class:`Graph`): a list of :class:`Graph` to execute.
-        targets (list): an optional list of step names to filter the graph to.
-            If provided, only these steps, and their transitive dependencies
-            will be executed. If no targets are specified, every node in the
-            graph will be executed.
-        reverse (bool): If provided, the graph will be walked in reverse order
-            (dependencies last).
-    """
+        Args:
+            stack_name (str): Name of a CloudFormation stack.
+            context (:class:`stacker.context.Context`): Context object.
+                Required to initialize a "fake" :class:`stacker.stack.Stack`.
+            requires (List[str]): Stacks that this stack depends on.
+            fn (Callable): The function to run to execute the step.
+                This function will be ran multiple times until the step
+                is "done".
+            watch_func (Callable): an optional function that will be
+                called to "tail" the step action.
 
-    # If we want to execute the plan in reverse (e.g. Destroy), transpose the
-    # graph.
-    if reverse:
-        graph = graph.transposed()
+        Returns:
+            (:class:`Step`)
 
-    # If we only want to build a specific target, filter the graph.
-    if targets:
-        nodes = []
-        for target in targets:
-            for k, step in graph.steps.items():
-                if step.name == target:
-                    nodes.append(step.name)
-        graph = graph.filtered(nodes)
+        """
+        from stacker.config import Stack as stack_conf
+        from stacker.stack import Stack
 
-    return Plan(description=description, graph=graph)
+        stack_def = stack_conf({'name': stack_name,
+                                'requires': requires or []})
+        stack = Stack(stack_def, context)
+        return cls(stack, fn=fn, watch_func=watch_func)
 
+    @classmethod
+    def from_persistent_graph(cls, graph_dict, context, fn=None,
+                              watch_func=None):
+        """Create a steps for a persistent graph dict.
 
-def build_graph(steps):
-    """Builds a graph of steps.
-    Args:
-        steps (list): a list of :class:`Step` objects to execute.
-    """
+        Args:
+            graph_dict (Dict[str, List[str]]): A graph dict.
+            context (:class:`stacker.context.Context`): Context object.
+                Required to initialize a "fake" :class:`stacker.stack.Stack`.
+            requires (List[str]): Stacks that this stack depends on.
+            fn (Callable): The function to run to execute the step.
+                This function will be ran multiple times until the step
+                is "done".
+            watch_func (Callable): an optional function that will be
+                called to "tail" the step action.
 
-    graph = Graph()
+        Returns:
+            (List[:class:`Step`])
 
-    for step in steps:
-        graph.add_step(step)
+        """
+        steps = []
 
-    for step in steps:
-        for dep in step.requires:
-            graph.connect(step.name, dep)
-
-        for parent in step.required_by:
-            graph.connect(parent, step.name)
-
-    return graph
+        for name, requires in graph_dict.items():
+            steps.append(cls.from_stack_name(name, context, requires,
+                                             fn, watch_func))
+        return steps
 
 
 class Graph(object):
@@ -238,18 +282,104 @@ class Graph(object):
     >>> dag.connect(a, b)
 
     Args:
-        steps (list): an optional list of :class:`Step` objects to execute.
+        steps (List[:class:`Step`]): an optional list of :class:`Step`
+            objects to execute.
         dag (:class:`stacker.dag.DAG`): an optional :class:`stacker.dag.DAG`
             object. If one is not provided, a new one will be initialized.
+
     """
+
+    def __str__(self):
+        return self.dumps()
 
     def __init__(self, steps=None, dag=None):
         self.steps = steps or {}
         self.dag = dag or DAG()
 
-    def add_step(self, step):
+    def add_step(self, step, add_dependencies=False, add_dependants=False):
+        """Add a step to the graph.
+
+        Args:
+            step (:class:`Step`): The step to be added.
+            add_dependencies (bool): Connect steps that need to be completed
+                before this step.
+            add_dependants (bool): Connect steps that require this step.
+
+        """
         self.steps[step.name] = step
         self.dag.add_node(step.name)
+
+        if add_dependencies:
+            for dep in step.requires:
+                self.connect(step.name, dep)
+
+        if add_dependants:
+            for parent in step.required_by:
+                self.connect(parent, step.name)
+
+    def add_step_if_not_exists(self, step, add_dependencies=False,
+                               add_dependants=False):
+        """Try to add a step to the graph.
+
+        Can be used when failure to add is acceptable.
+
+        Args:
+            step (:class:`Step`): The step to be added.
+            add_dependencies (bool): Connect steps that need to be completed
+                before this step.
+            add_dependants (bool): Connect steps that require this step.
+
+        """
+        if self.steps.get(step.name):
+            return
+
+        self.steps[step.name] = step
+        self.dag.add_node_if_not_exists(step.name)
+
+        if add_dependencies:
+            for dep in step.requires:
+                try:
+                    self.connect(step.name, dep)
+                except GraphError:
+                    continue
+
+        if add_dependants:
+            for parent in step.required_by:
+                try:
+                    self.connect(parent, step.name)
+                except GraphError:
+                    continue
+
+    def add_steps(self, steps):
+        """Add a list of steps.
+
+        Args:
+            steps (List[:class:`Step`]): The step to be added.
+
+        """
+        for step in steps:
+            self.add_step(step)
+
+        for step in steps:
+            for dep in step.requires:
+                self.connect(step.name, dep)
+
+            for parent in step.required_by:
+                self.connect(parent, step.name)
+
+    def pop(self, step, default=None):
+        """Remove a step from the graph.
+
+        Args:
+            step: (:class:`Step`): The step to remove from the graph.
+            default (Any): Returned if the step could not be popped
+
+        Returns:
+            (Any)
+
+        """
+        self.dag.delete_node_if_exists(step.name)
+        return self.steps.pop(step.name, default)
 
     def connect(self, step, dep):
         try:
@@ -290,28 +420,105 @@ class Graph(object):
     def to_dict(self):
         return self.dag.graph
 
+    def dumps(self, indent=None):
+        """Output the graph as a json seralized string for storage.
+
+        Args:
+            indent (Optional[int]): Number of spaces for each indentation.
+
+        Returns:
+            (str)
+
+        """
+        return json.dumps(self.to_dict(), default=json_serial, indent=indent)
+
+    @classmethod
+    def from_dict(cls, graph_dict, context):
+        """Create a Graph from a graph dict.
+
+        Args:
+            graph_dict (Dict[str, List[str]]): The dictionary used to
+                create the graph.
+            context (:class:`stacker.context.Context`): Required to init
+                stacks.
+
+        Returns:
+            (:class:`Graph`)
+
+        """
+        return cls.from_steps(Step.from_persistent_graph(graph_dict, context))
+
+    @classmethod
+    def from_steps(cls, steps):
+        """Create a Graph from Steps.
+
+        Args:
+            steps (List[:class:`Step`]): Steps used to create the graph.
+
+        Returns:
+            (:class:`Graph`)
+
+        """
+        graph = cls()
+        graph.add_steps(steps)
+        return graph
+
 
 class Plan(object):
     """A convenience class for working on a Graph.
+
     Args:
         description (str): description of the plan.
         graph (:class:`Graph`): a graph of steps.
+
     """
 
-    def __init__(self, description, graph):
-        self.id = uuid.uuid4()
+    def __str__(self):
+        return self.graph.dumps()
+
+    def __init__(self, context, description, graph, reverse=False,
+                 require_unlocked=True):
+        """Initialize class.
+
+        Args:
+            context (:class:`stacker.context.Context`): Context object.
+            description (str): Description of what the plan is going to do.
+            graph (:class:`Graph`): Local graph used for the plan.
+            reverse (bool): Transpose the graph for walking in reverse.
+            require_unlocked (bool): Require the persistent graph to be
+                unlocked before executing steps.
+
+        """
+        self.context = context
         self.description = description
-        self.graph = graph
+        self.id = uuid.uuid4()
+        self.locked = context.persistent_graph_locked
+        self.reverse = reverse
+        self.require_unlocked = require_unlocked
+
+        if self.reverse:
+            graph = graph.transposed()
+
+        if self.context.stack_names:
+            nodes = []
+            for target in self.context.stack_names:
+                if graph.steps.get(target):
+                    nodes.append(target)
+            self.graph = graph.filtered(nodes)
+        else:
+            self.graph = graph
 
     def outline(self, level=logging.INFO, message=""):
         """Print an outline of the actions the plan is going to take.
         The outline will represent the rough ordering of the steps that will be
         taken.
+
         Args:
             level (int, optional): a valid log level that should be used to log
                 the outline
             message (str, optional): a message that will be logged to
                 the user after the outline has been logged.
+
         """
         steps = 1
         logger.log(level, "Plan \"%s\":", self.description)
@@ -360,8 +567,14 @@ class Plan(object):
         any of the steps fail.
 
         Raises:
+            PersistentGraphLocked: Raised if the persistent graph is
+                locked prior to execution and this session did not lock it.
             PlanFailed: Raised if any of the steps fail.
+
         """
+        if self.locked and self.require_unlocked:
+            raise PersistentGraphLocked
+
         self.walk(*args, **kwargs)
 
         failed_steps = [step for step in self.steps if step.status == FAILED]
@@ -377,6 +590,17 @@ class Plan(object):
         """
 
         def walk_func(step):
+            """Execute a :class:`Step` wile walking the graph.
+
+            Handles updating the persistent graph if one is being used.
+
+            Args:
+                step (:class:`Step`): :class:`Step` to execute.
+
+            Returns:
+                (bool)
+
+            """
             # Before we execute the step, we need to ensure that it's
             # transitive dependencies are all in an "ok" state. If not, we
             # won't execute this step.
@@ -385,9 +609,40 @@ class Plan(object):
                     step.set_status(FailedStatus("dependency has failed"))
                     return step.ok
 
-            return step.run()
+            result = step.run()
+
+            if not self.context.persistent_graph:
+                return result
+
+            if (step.completed or
+                    (step.skipped and
+                     step.status.reason == ('does not exist in '
+                                            'cloudformation'))):
+                if step.fn.__name__ == '_destroy_stack':
+                    self.context.persistent_graph.pop(step)
+                    logger.debug("Removed step '%s' from the persistent graph",
+                                 step.name)
+                elif step.fn.__name__ == '_launch_stack':
+                    self.context.persistent_graph.add_step_if_not_exists(
+                        step, add_dependencies=True, add_dependants=True
+                    )
+                    logger.debug("Added step '%s' to the persistent graph",
+                                 step.name)
+                else:
+                    return result
+                self.context.put_persistent_graph(self.lock_code)
 
         return self.graph.walk(walker, walk_func)
+
+    @property
+    def lock_code(self):
+        """Used for locking/unlocking the persistent graph.
+
+        Returns:
+            (str)
+
+        """
+        return str(self.id)
 
     @property
     def steps(self):


### PR DESCRIPTION
- update provider destroy_stack method to have an interactive mode
- pass region option into context
- add persist graph to context
  - context method to get graph
  - context method to lock graph
  - context method to unlock graph
  - context method to put graph
- add persistent graph exceptions
- update ensure_s3_bucket
  - check for recommended bucket settings
  - applies recommended settings if creating a bucket
- update plan
  - class methods to create Step and Graph
  - remove build_graph
  - remove build_plan, all logic is now in __init__
  - add persistent graph management
  - add more methods for manipulating the graph
- update base action
  - add handling for persistent graph
  - move plan creation to a method that uses classmethods of Graph and Plan
- update graph action
  - uses parent class method to create plan
  - can include persistent graph
- update diff action
  - uses parent class method to create plan
  - can include persistent graph
- update build action
  - custom method to create plan that deletes stacks that are in the persistent graph but are no longer in the local graph
- update destroy action
  - uses parent class method to create plan
  - can include persistent graph
- add persistent_graph_key to config